### PR TITLE
Allow Configuring `Image` for MetalMachines

### DIFF
--- a/api/v1alpha1/metalmachine_types.go
+++ b/api/v1alpha1/metalmachine_types.go
@@ -26,6 +26,9 @@ type MetalMachineSpec struct {
 	// +optional
 	ProviderID *string `json:"providerID,omitempty"`
 
+	// Image specifies the boot image to be used for the server.
+	Image string `json:"image"`
+
 	// ServerSelector specifies matching criteria for labels on Servers.
 	// This is used to claim specific Server types for a MetalMachine.
 	// +optional

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metalmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metalmachines.yaml
@@ -39,6 +39,9 @@ spec:
           spec:
             description: MetalMachineSpec defines the desired state of MetalMachine
             properties:
+              image:
+                description: Image specifies the boot image to be used for the server.
+                type: string
               providerID:
                 description: ProviderID is the unique identifier as specified by the
                   cloud provider.
@@ -55,6 +58,8 @@ spec:
                       Server
                     type: object
                 type: object
+            required:
+            - image
             type: object
           status:
             description: MetalMachineStatus defines the observed state of MetalMachine

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metalmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metalmachinetemplates.yaml
@@ -71,6 +71,10 @@ spec:
                   spec:
                     description: MetalMachineSpec defines the desired state of MetalMachine
                     properties:
+                      image:
+                        description: Image specifies the boot image to be used for
+                          the server.
+                        type: string
                       providerID:
                         description: ProviderID is the unique identifier as specified
                           by the cloud provider.
@@ -87,6 +91,8 @@ spec:
                               on a chosen Server
                             type: object
                         type: object
+                    required:
+                    - image
                     type: object
                 required:
                 - spec

--- a/config/samples/infrastructure_v1alpha1_metalmachinetemplate.yaml
+++ b/config/samples/infrastructure_v1alpha1_metalmachinetemplate.yaml
@@ -11,3 +11,4 @@ spec:
       serverSelector:
         matchLabels:
           server: metal
+      image: ghcr.io/ironcore-dev/os-images/gardenlinux:1443.3

--- a/internal/controller/metalmachine_controller.go
+++ b/internal/controller/metalmachine_controller.go
@@ -297,8 +297,7 @@ func (r *MetalMachineReconciler) applyServerClaim(ctx context.Context, log *logr
 			IgnitionSecretRef: &corev1.LocalObjectReference{
 				Name: ignitionsecret.Name,
 			},
-			// TODO: Allow configuring os-image.
-			Image: "ghcr.io/ironcore-dev/os-images/gardenlinux:1443.3",
+			Image: metalmachine.Spec.Image,
 		},
 	}
 


### PR DESCRIPTION
# Proposed Changes

- require an image to be used for `ServerClaim`

Fixes https://github.com/ironcore-dev/cluster-api-provider-metal/issues/18