### PR TITLE
Support setting node Hostname to match Serverclaim name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot AS manager
+LABEL source_repository="https://github.com/ironcore-dev/cluster-api-provider-metal"
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/templates/test/cluster_v1beta1_cluster.yaml
+++ b/templates/test/cluster_v1beta1_cluster.yaml
@@ -4,10 +4,10 @@ metadata:
   name: cluster-sample
 spec:
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: KubeadmControlPlane
     name: kubeadmcontrolplane-sample-cp
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
     kind: MetalCluster
     name: metalcluster-sample

--- a/templates/test/cluster_v1beta1_kubeadmcontrolplane.yaml
+++ b/templates/test/cluster_v1beta1_kubeadmcontrolplane.yaml
@@ -40,6 +40,5 @@ spec:
                 [TEST]
                 test=1
     preKubeadmCommands:
-    - envsubst < /etc/kubeadm.yml > /etc/kubeadm.yml.tmp
-    - mv /etc/kubeadm.yml.tmp /etc/kubeadm.yml
+    - hostnamectl set-hostname $${METAL_HOSTNAME}
   version: 1.29.4


### PR DESCRIPTION
# Proposed Changes

- this adds ability to use `$${METAL_HOSTNAME}` in kubeadmconfigtemplate to set nodes hostname. It will be replaced by metalmachine (and ServerClaim) name in ignition.
 
Original CAPBK generated ignition is not modified - we only modify the secret created by metalmachine controller.