### PR TITLE
Add polling of server claim before setting its ownership to ips

### DIFF
--- a/internal/controller/ironcoremetalmachine_controller.go
+++ b/internal/controller/ironcoremetalmachine_controller.go
@@ -508,10 +508,11 @@ func (r *IroncoreMetalMachineReconciler) patchIroncoreMetalMachineProviderID(ctx
 }
 
 func (r *IroncoreMetalMachineReconciler) setServerClaimOwnership(ctx context.Context, serverClaim *metalv1alpha1.ServerClaim, IPAddressClaims []*capiv1beta1.IPAddressClaim) error {
+	// wait for the server claim to be visible in a cache
 	err := wait.PollUntilContextTimeout(
 		ctx,
-		time.Millisecond*50,
-		time.Millisecond*340,
+		50*time.Millisecond,
+		340*time.Millisecond,
 		true,
 		func(ctx context.Context) (bool, error) {
 			if err := r.Get(ctx, client.ObjectKeyFromObject(serverClaim), serverClaim); err != nil {


### PR DESCRIPTION
# Proposed Changes

When an owner reference to a `ServerClaim` is made for `IPAddressClaim`s we need to wait until the `ServerClaim` is created so there is added polling.