### PR TITLE
Fix e2e cluster template

### DIFF
--- a/test/e2e/data/infrastructure-ironcore-metal/v0.3.0/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-ironcore-metal/v0.3.0/cluster-template.yaml
@@ -11,7 +11,7 @@ spec:
     pods:
       cidrBlocks: ["${POD_CIDR:=192.168.0.0/16}"]
     services:
-      cidrBlocks: ["${POD_CIDR:=10.96.0.0/12}"]
+      cidrBlocks: ["${SERVICE_CIDR:=10.96.0.0/12}"]
   controlPlaneRef:
     apiGroup: controlplane.cluster.x-k8s.io
     apiVersion: controlplane.cluster.x-k8s.io/v1beta2
@@ -151,8 +151,10 @@ spec:
         nodeRegistration:
           name: $${METAL_HOSTNAME}
           kubeletExtraArgs:
-            cloud-provider: external
-            provider-id: "ironcore://$${METAL_HOSTNAME}"
+            - name: cloud-provider
+              value: external
+            - name: provider-id
+              value: "ironcore://$${METAL_HOSTNAME}"
       format: ignition
       preKubeadmCommands:
         - hostnamectl set-hostname $${METAL_HOSTNAME}


### PR DESCRIPTION
Fix e2e cluster template by:
- differentiating between pod and service CIDR
- update KubeadmConfigTemplate to be v1beta2 compatible

Couple of small nits i came across while looking into the e2e setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the default service network CIDR configuration.
  * Updated worker node kubelet settings to use a compatible argument format.
  * Aligned the worker IPAM pool reference with the cluster configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->