### PR TITLE
Add support for tolerations

### DIFF
--- a/api/v1alpha1/ironcoremetalmachine_types.go
+++ b/api/v1alpha1/ironcoremetalmachine_types.go
@@ -6,6 +6,7 @@ package v1alpha1
 import (
 	"time"
 
+	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,6 +34,11 @@ type IroncoreMetalMachineSpec struct {
 	// This is used to claim specific Server types for a IroncoreMetalMachine.
 	// +optional
 	ServerSelector *metav1.LabelSelector `json:"serverSelector,omitempty"`
+
+	// Tolerations allow the resulting ServerClaim to bind to a Server with
+	// matching taints.
+	// +optional
+	Tolerations []metalv1alpha1.Toleration `json:"tolerations,omitempty"`
 
 	// IPAMConfig is a list of references to Network resources that should be used to assign IP addresses to the worker nodes.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -5,6 +5,7 @@
 package v1alpha1
 
 import (
+	apiv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -341,6 +342,11 @@ func (in *IroncoreMetalMachineSpec) DeepCopyInto(out *IroncoreMetalMachineSpec) 
 		in, out := &in.ServerSelector, &out.ServerSelector
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]apiv1alpha1.Toleration, len(*in))
+		copy(*out, *in)
 	}
 	if in.IPAMConfig != nil {
 		in, out := &in.IPAMConfig, &out.IPAMConfig

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ironcoremetalmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ironcoremetalmachines.yaml
@@ -133,6 +133,41 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              tolerations:
+                description: |-
+                  Tolerations allow the resulting ServerClaim to bind to a Server with
+                  matching taints.
+                items:
+                  description: |-
+                    Toleration allows a ServerClaim to tolerate taints on a Server so that
+                    the claim can be bound to a server that would otherwise be restricted.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to tolerate.
+                      enum:
+                      - NoBind
+                      - Evict
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to.
+                      minLength: 1
+                      type: string
+                    operator:
+                      description: Operator represents the key's relationship to the
+                        value.
+                      enum:
+                      - Equal
+                      - Exists
+                      type: string
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to.
+                      type: string
+                  required:
+                  - key
+                  type: object
+                type: array
             required:
             - image
             type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ironcoremetalmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ironcoremetalmachinetemplates.yaml
@@ -171,6 +171,41 @@ spec:
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
+                      tolerations:
+                        description: |-
+                          Tolerations allow the resulting ServerClaim to bind to a Server with
+                          matching taints.
+                        items:
+                          description: |-
+                            Toleration allows a ServerClaim to tolerate taints on a Server so that
+                            the claim can be bound to a server that would otherwise be restricted.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to tolerate.
+                              enum:
+                              - NoBind
+                              - Evict
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to.
+                              minLength: 1
+                              type: string
+                            operator:
+                              description: Operator represents the key's relationship
+                                to the value.
+                              enum:
+                              - Equal
+                              - Exists
+                              type: string
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to.
+                              type: string
+                          required:
+                          - key
+                          type: object
+                        type: array
                     required:
                     - image
                     type: object

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -561,6 +561,19 @@ This is used to claim specific Server types for a IroncoreMetalMachine.</p>
 </tr>
 <tr>
 <td>
+<code>tolerations</code><br/>
+<em>
+[]github.com/ironcore-dev/metal-operator/api/v1alpha1.Toleration
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Tolerations allow the resulting ServerClaim to bind to a Server with
+matching taints.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>ipamConfig</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1alpha1.IPAMConfig">
@@ -685,6 +698,19 @@ Kubernetes meta/v1.LabelSelector
 <em>(Optional)</em>
 <p>ServerSelector specifies matching criteria for labels on Servers.
 This is used to claim specific Server types for a IroncoreMetalMachine.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tolerations</code><br/>
+<em>
+[]github.com/ironcore-dev/metal-operator/api/v1alpha1.Toleration
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Tolerations allow the resulting ServerClaim to bind to a Server with
+matching taints.</p>
 </td>
 </tr>
 <tr>
@@ -912,6 +938,19 @@ Kubernetes meta/v1.LabelSelector
 <em>(Optional)</em>
 <p>ServerSelector specifies matching criteria for labels on Servers.
 This is used to claim specific Server types for a IroncoreMetalMachine.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tolerations</code><br/>
+<em>
+[]github.com/ironcore-dev/metal-operator/api/v1alpha1.Toleration
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Tolerations allow the resulting ServerClaim to bind to a Server with
+matching taints.</p>
 </td>
 </tr>
 <tr>

--- a/internal/controller/ironcoremetalmachine_controller.go
+++ b/internal/controller/ironcoremetalmachine_controller.go
@@ -472,6 +472,7 @@ func (r *IroncoreMetalMachineReconciler) applyServerClaim(ctx context.Context, l
 			},
 			Image:          ironcoremetalmachine.Spec.Image,
 			ServerSelector: ironcoremetalmachine.Spec.ServerSelector,
+			Tolerations:    ironcoremetalmachine.Spec.Tolerations,
 		},
 	}
 

--- a/internal/controller/ironcoremetalmachine_controller_test.go
+++ b/internal/controller/ironcoremetalmachine_controller_test.go
@@ -395,6 +395,51 @@ var _ = Describe("IroncoreMetalMachine Controller", func() {
 				Expect(metalMachine.Status.Initialization).NotTo(BeNil())
 				Expect(*metalMachine.Status.Initialization.Provisioned).To(BeTrue())
 			})
+
+			When("the tolerations are present in the metal machine", func() {
+				BeforeEach(func() {
+					metalMachine.Spec.Tolerations = []metalv1alpha1.Toleration{
+						{
+							Key:      "metal.ironcore.dev/maintenance",
+							Operator: metalv1alpha1.TolerationOperatorEqual,
+							Value:    "true",
+							Effect:   metalv1alpha1.TaintEffectNoBind,
+						},
+						{
+							Key:      "metal.ironcore.dev/reserved",
+							Operator: metalv1alpha1.TolerationOperatorExists,
+						},
+					}
+				})
+
+				It("should create the ServerClaim with the tolerations", func() {
+					_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+						NamespacedName: client.ObjectKeyFromObject(metalMachine),
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					serverClaim := &metalv1alpha1.ServerClaim{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      metalMachine.Name,
+							Namespace: namespace,
+						},
+					}
+					Eventually(Object(serverClaim)).Should(
+						HaveField("Spec.Tolerations", Equal(metalMachine.Spec.Tolerations)))
+				})
+			})
+
+			It("should create the ServerClaim without tolerations when none are set", func() {
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: client.ObjectKeyFromObject(metalMachine),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				serverClaim := &metalv1alpha1.ServerClaim{}
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(metalMachine), serverClaim)).To(Succeed())
+				Expect(serverClaim.Spec.Tolerations).To(BeEmpty())
+			})
+
 		})
 	})
 })


### PR DESCRIPTION
# Proposed Changes
Add a Tolerations field to IroncoreMetalMachineSpec, reusing metal-operator's Toleration type, and pass it through when creating the ServerClaim. This lets a machine bind to Servers carrying taints that would otherwise restrict it.

Fixes #194 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional toleration settings for metal machines and machine templates.
  * Tolerations are propagated to server claims, enabling matching with servers carrying compatible taints.
  * Supported operators and effects are validated through the resource schema.

* **Documentation**
  * Updated API reference documentation with the new toleration configuration.

* **Tests**
  * Added coverage for configured and absent tolerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->